### PR TITLE
Improve stream buff

### DIFF
--- a/src/grpc/clientserver.nim
+++ b/src/grpc/clientserver.nim
@@ -235,3 +235,10 @@ proc failSilently*(fut: Future[void]) {.async.} =
       await fut
   except HyperxError, GrpcFailure:
     debugErr getCurrentException()
+
+proc testBuffAll*(strm: GrpcStream) {.async.} =
+  ## for testing purposes; buff all recv data
+  if strm.headers[].len == 0:
+    await strm.recvHeaders()
+  while not strm.stream.recvEnded:
+    catchHyperx await strm.stream.recvBody(strm.buff.s)

--- a/tests/hello.proto
+++ b/tests/hello.proto
@@ -2,6 +2,7 @@ syntax = "proto3";
 
 service Greeter {
   rpc TestHello (HelloRequest) returns (HelloReply) {}
+  rpc TestHelloUni (HelloRequest) returns (stream HelloReply) {}
   rpc TestHelloBidi (stream HelloRequest) returns (stream HelloReply) {}
 }
 

--- a/tests/testserver.nim
+++ b/tests/testserver.nim
@@ -17,6 +17,13 @@ proc testHello(strm: GrpcStream) {.async.} =
     HelloReply(message: "Hello, " & request.name)
   )
 
+proc testHelloUni(strm: GrpcStream) {.async.} =
+  let request = await strm.recvMessage(HelloRequest)
+  for i in 0 .. 9:
+    await strm.sendMessage(
+      HelloReply(message: "Hello, " & request.name & " " & $i)
+    )
+
 proc testHelloBidi(strm: GrpcStream) {.async.} =
   whileRecvMessages strm:
     let request = await strm.recvMessage(HelloRequest)
@@ -29,6 +36,7 @@ proc main() {.async.} =
   let server = newServer(localHost, localPort, certFile, keyFile)
   await server.serve(@[
     (GreeterTestHelloPath, testHello.GrpcCallback),
+    (GreeterTestHelloUniPath, testHelloUni.GrpcCallback),
     (GreeterTestHelloBidiPath, testHelloBidi.GrpcCallback),
   ])
 


### PR DESCRIPTION
Improve buffer usage when it contains more than one message (ex: unidirectional streaming). It should not affect receiving just one message (simple request/response, and ping-pong streaming).